### PR TITLE
서버 카카오 로그인 / 로그아웃

### DIFF
--- a/contorollers/authController.js
+++ b/contorollers/authController.js
@@ -8,8 +8,7 @@ exports.login = async (req, res, next) => {
     const userInfo = req.body;
 
     if (!userInfo.email) {
-      next(createError(401, { message: constants.ERROR_UNAUTHORIZE }));
-      return;
+      return next(createError(401, { message: constants.ERROR_UNAUTHORIZE }));
     }
 
     const accessToken = jwt.sign(
@@ -41,6 +40,7 @@ exports.login = async (req, res, next) => {
     });
 
     let user = await authService.getUser(userInfo.email);
+
     if (!user) {
       user = await authService.createUser(userInfo, userInfo.location);
     } else {
@@ -53,7 +53,7 @@ exports.login = async (req, res, next) => {
   }
 };
 
-exports.logout = async (req, res, next) => {
+exports.logout = (req, res, next) => {
   res.clearCookie("accessToken");
   res.clearCookie("refreshToken");
   res.json({ success: constants.SUCCESS });

--- a/contorollers/authController.js
+++ b/contorollers/authController.js
@@ -3,41 +3,48 @@ const authService = require("../services/authService");
 const roomService = require("../services/roomService");
 const communityService = require("../services/communityService");
 const constants = require("../utils/constants");
-const User = require("../models/User");
 
 exports.login = async (req, res) => {
-  const { name, email, profile, age_range, gender } = req.body;
+  try {
+    const userInfo = req.body;
 
-  if (!email) {
-    return res.json("이메일 항목에 동의해주세요"); //테스트 중입니다
-  }
+    if (!userInfo.email) {
+      return res.json("이메일 항목에 동의해주세요"); //테스트 중입니다
+    }
 
-  const accessToken = jwt.sign({ email: email }, process.env.COOKIE_SECRET, {
-    expiresIn: "1h", //토큰 만료 시간
-  });
+    const accessToken = jwt.sign(
+      { email: userInfo.email },
+      process.env.JWT_ACCESS_TOKEN_SECRET,
+      {
+        expiresIn: "1h",
+      }
+    );
 
-  const refreshToken = jwt.sign({ email: email }, process.env.JWT_SECRET, {
-    expiresIn: "7d",
-  });
+    const refreshToken = jwt.sign(
+      { email: userInfo.email },
+      process.env.JWT_REFRESH_SECRET,
+      {
+        expiresIn: "7d",
+      }
+    );
 
-  res.cookie("access_token", accessToken, {
-    httpOnly: true,
-    maxAge: 24 * 60 * 60 * 1000,
-  });
-
-  const user = await authService.getUser(email, refreshToken);
-  if (!user) {
-    await User.create({
-      name,
-      email,
-      profile,
-      age_range,
-      gender,
-      refresh_token: refreshToken,
+    res.cookie("access_token", accessToken, {
+      httpOnly: true,
+      maxAge: 3600,
     });
-  }
 
-  res.status(200).json(user);
+    let user = await authService.getUser(userInfo.email);
+
+    if (!user) {
+      user = await authService.createUser(userInfo, refreshToken);
+    } else {
+      await authService.saveRefreshToken(user, refreshToken);
+    }
+
+    res.status(200).json(user);
+  } catch (err) {
+    console.log(err);
+  }
 };
 
 exports.refresh = async (req, res) => {};

--- a/middlewares/authorization.js
+++ b/middlewares/authorization.js
@@ -1,0 +1,57 @@
+const jwt = require("jsonwebtoken");
+const createError = require("http-errors");
+const constants = require("../utils/constants");
+
+exports.refresh = async (req, res, next) => {
+  try {
+    const userEmail = jwt.verify(
+      req.signedCookies.accessToken,
+      process.env.JWT_ACCESS_TOKEN_SECRET
+    );
+
+    req.userEmail = userEmail;
+
+    next();
+  } catch (error) {
+    if (error.name === "TokenExpiredError") {
+      try {
+        const userEmail = jwt.verify(
+          req.signedCookies.refreshToken,
+          process.env.JWT_REFRESH_TOKEN_SECRET
+        );
+
+        req.userEmail = userEmail;
+
+        res.cookie("accessToken", req.signedCookies.refreshToken, {
+          httpOnly: true,
+          maxAge: 3 * 60 * 60 * 1000,
+          signed: true,
+        });
+
+        const refreshToken = jwt.sign(
+          { email: userEmail },
+          process.env.JWT_REFRESH_TOKEN_SECRET,
+          {
+            expiresIn: "2d",
+          }
+        );
+
+        res.cookie("refreshToken", refreshToken, {
+          httpOnly: true,
+          maxAge: 48 * 60 * 60 * 1000,
+          signed: true,
+        });
+
+        next();
+      } catch (error) {
+        res.clearCookie("accessToken");
+        res.clearCookie("refreshToken");
+        return next(createError(400, { message: constants.ERROR_TOKEN }));
+      }
+    }
+
+    res.clearCookie("accessToken");
+    res.clearCookie("refreshToken");
+    next(createError(500, { message: constants.ERROR_INVALID_SERVER }));
+  }
+};

--- a/middlewares/authorization.js
+++ b/middlewares/authorization.js
@@ -2,7 +2,7 @@ const jwt = require("jsonwebtoken");
 const createError = require("http-errors");
 const constants = require("../utils/constants");
 
-exports.refresh = async (req, res, next) => {
+exports.refresh = (req, res, next) => {
   try {
     const userEmail = jwt.verify(
       req.signedCookies.accessToken,
@@ -46,6 +46,7 @@ exports.refresh = async (req, res, next) => {
       } catch (error) {
         res.clearCookie("accessToken");
         res.clearCookie("refreshToken");
+
         return next(createError(400, { message: constants.ERROR_TOKEN }));
       }
     }

--- a/middlewares/isLogged.js
+++ b/middlewares/isLogged.js
@@ -1,0 +1,22 @@
+const createError = require("http-errors");
+const constants = require("../utils/constants");
+
+exports.isLoggedIn = (req, res, next) => {
+  const token = req.signedCookies.accessToken;
+
+  if (token) {
+    next(createError(400, { message: constants.ERROR_BAD_REQUEST }));
+  } else {
+    next();
+  }
+};
+
+exports.isNotLoggedIn = (req, res, next) => {
+  const token = req.signedCookies.accessToken;
+
+  if (!token) {
+    next(createError(400, { message: constants.ERROR_BAD_REQUEST }));
+  } else {
+    next();
+  }
+};

--- a/models/User.js
+++ b/models/User.js
@@ -28,7 +28,6 @@ const userSchema = new mongoose.Schema({
   },
   current_address: {
     type: String,
-    // required: true,
     minlength: [1, "지역이름은 최소 1자 이상이어야 합니다."],
   },
 });

--- a/models/User.js
+++ b/models/User.js
@@ -31,11 +31,6 @@ const userSchema = new mongoose.Schema({
     // required: true,
     minlength: [1, "지역이름은 최소 1자 이상이어야 합니다."],
   },
-  refresh_token: {
-    type: String,
-    // required: true,
-    // minlength: [validator.isJWT, "jwt 토큰이 형식이 아닙니다."],
-  },
 });
 
 module.exports = mongoose.model("User", userSchema);

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,11 +1,10 @@
 const express = require("express");
 const router = express.Router();
 const authController = require("../contorollers/authController");
-// const constants = require("../utils/constants");
+const { isLoggedIn, isNotLoggedIn } = require("../middlewares/isLogged");
 
-router.post("/login", authController.login);
+router.post("/login", isLoggedIn, authController.login);
 
-router.post("/refresh", authController.refresh);
-router.get("/logout", authController.logout);
+router.get("/logout", isNotLoggedIn, authController.logout);
 
 module.exports = router;

--- a/routes/room.js
+++ b/routes/room.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const router = express.Router();
 const roomController = require("../contorollers/roomController");
-const constants = require("../utils/constants");
 
 router.get("/", roomController.getRooms);
 

--- a/services/authService.js
+++ b/services/authService.js
@@ -4,18 +4,18 @@ exports.getUser = async (email) => {
   return await User.findOne({ email });
 };
 
-exports.createUser = async (userInfo, refreshToken) => {
+exports.createUser = async (userInfo, address) => {
   return await User.create({
     name: userInfo.name,
     email: userInfo.email,
     profile: userInfo.profile,
     age_range: userInfo.age_range,
     gender: userInfo.gender,
-    refresh_token: refreshToken,
+    current_address: address,
   });
 };
 
-exports.saveRefreshToken = async (user, refreshToken) => {
-  user.refresh_token = refreshToken;
+exports.saveAddress = async (user, address) => {
+  user.current_address = address;
   await user.save();
 };

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,9 +1,21 @@
 const User = require("../models/User");
 
-exports.getUser = async (email, refreshToken) => {
-  const user = await User.findOne({ email });
+exports.getUser = async (email) => {
+  return await User.findOne({ email });
+};
+
+exports.createUser = async (userInfo, refreshToken) => {
+  return await User.create({
+    name: userInfo.name,
+    email: userInfo.email,
+    profile: userInfo.profile,
+    age_range: userInfo.age_range,
+    gender: userInfo.gender,
+    refresh_token: refreshToken,
+  });
+};
+
+exports.saveRefreshToken = async (user, refreshToken) => {
   user.refresh_token = refreshToken;
   await user.save();
-
-  return user;
 };


### PR DESCRIPTION
# 서버 카카오 로그인 로그아웃 인증 구현
제목: 카카오 로그인 로그아웃 및 토큰 인증 구현
## 노션 칸반 링크
- [서버 카카오 로그인 / 로그아웃]
 https://www.notion.so/vanillacoding/deb954872da3418cb2c11be7631d6d85?v=01516eecd01648199792cb7bef42e047&p=069adce498e54744984aaaa10ac21ddb
​
## 카드에서 구현 혹은 해결하려는 내용
1. 토큰검증 미들웨어를 작성해 로그인 상태를 식별하는 기능

2. 토큰을 verify하여 검증을 하는 기능

  토큰 verify가 된다면 이미 로그인한 유저이므로 에러 응답

3. verify시 토큰 만료 에러가 발생한다면 User의 refresh_token을 가져와 쿠키에 저장된

  토큰값을 변경하고 해당 토큰 값으로 verify 할 수 있도록 구현

4. isLoggedIn, isNotLoggedIn 미들웨어 구현 후 적용

5. token , refreshToken 으로 Jwt 토큰을 2개 생성합니다.

token을 쿠키에 등록합니다.

6. 모두 통과시 User DB에 같은 정보가 있는지 확인 후 token만드는 기능 구현

정보가 있을 때: token을 생성해 쿠키에 저장합니다

정보가 없을 때: User DB에 정보를 추가한 뒤 token을 생성해 쿠키에 저장합니다
​
7. access token을 둘다 쿠키에 넣어 구현
8. access token이 만료되고 refresh token이 만료되지 않았으면 access token을 refresh token으로 변경
9. access token이 만료되고 refresh token이 만료되었으면 로그인 재요청 

## 로그아웃 요청
- 클라이언트에서 로그아웃 요청시 login된 상태가 맞는지 체크 하도록 로그인시 구현한 미들웨어를 활용
    
    → 로그인이 안된상태라면 에러를 응답하고
    
    → 로그인이 된 상태라면 쿠키를 지웁니다

## 카드에서 해결하려는 내용
-  로그인 요청시 넘어오는 정보들의 유효성 검사가 필요합니다. ( joi 를 이용)
< 이름, 이메일, 프로필이미지, 성별, 출생연도, 현재주소>

## 기타 사항
- 저번에 있었던 이슈 사항 mongoose findOne에 대한 이슈(데이터에 user가 없으면 가장 첫번째 유저를 반환하는 이슈)는 
email로 user을 찾기 때문에 findOne 으로 유저를 찾아야 할 것 같습니다
만약 유저 이메일이 없으면 next로 에러 메세지를 보냈기때문에 문제가 없을 것 같은데 혹시 두분은 어떻게 생각하시는지 궁금합니다



